### PR TITLE
Fix AG Grid table not rendering on Step 8

### DIFF
--- a/src/components/ItemsTable/ItemsGrid.tsx
+++ b/src/components/ItemsTable/ItemsGrid.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useRef } from 'react';
 import { AgGridReact } from 'ag-grid-react';
 import type { ColDef, GridReadyEvent, CellValueChangedEvent, GetRowIdParams, RowClassRules } from 'ag-grid-community';
+import { themeQuartz } from 'ag-grid-community';
 import './gridSetup';
 import './ardaGridTheme.css';
 import type { MasterListItem, RowSyncState } from './types';
@@ -12,6 +13,33 @@ import { ColorCellEditor } from './cellRenderers/ColorCellEditor';
 import { SyncStatusRenderer } from './cellRenderers/SyncStatusRenderer';
 import { ActionsCellRenderer } from './cellRenderers/ActionsCellRenderer';
 import { UrlCellRenderer } from './cellRenderers/UrlCellRenderer';
+
+const ardaTheme = themeQuartz.withParams({
+  fontFamily: "'Inter', system-ui, -apple-system, sans-serif",
+  fontSize: 13,
+  backgroundColor: '#ffffff',
+  headerBackgroundColor: '#f9fafb',
+  oddRowBackgroundColor: '#ffffff',
+  rowHoverColor: '#f9fafb',
+  headerCellHoverBackgroundColor: '#f3f4f6',
+  selectedRowBackgroundColor: '#fff7ed',
+  modalOverlayBackgroundColor: 'rgba(0, 0, 0, 0.3)',
+  rangeSelectionBorderColor: '#FC5A29',
+  rangeSelectionBackgroundColor: 'rgba(252, 90, 41, 0.08)',
+  accentColor: '#FC5A29',
+  borderColor: '#e5e7eb',
+  headerTextColor: '#4b5563',
+  foregroundColor: '#1f2937',
+  subtleTextColor: '#6b7280',
+  spacing: 4,
+  cellHorizontalPadding: 8,
+  headerHeight: 36,
+  rowHeight: 38,
+  wrapperBorderRadius: 12,
+  borderRadius: 6,
+  cardShadow: '0 1px 3px 0 rgba(0,0,0,0.1), 0 1px 2px -1px rgba(0,0,0,0.1)',
+  popupShadow: '0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -2px rgba(0,0,0,0.1)',
+});
 
 export interface ItemsGridProps {
   items: MasterListItem[];
@@ -265,6 +293,7 @@ export const ItemsGrid: React.FC<ItemsGridProps> = ({
       <div className="ag-theme-arda flex-1" style={{ height: containerHeight, width: '100%' }}>
         <AgGridReact<MasterListItem>
           ref={gridRef}
+          theme={ardaTheme}
           rowData={items}
           columnDefs={columnDefs}
           defaultColDef={defaultColDef}

--- a/src/components/ItemsTable/ardaGridTheme.css
+++ b/src/components/ItemsTable/ardaGridTheme.css
@@ -1,49 +1,5 @@
-.ag-theme-arda {
-  --ag-font-family: 'Inter', system-ui, -apple-system, sans-serif;
-  --ag-font-size: 13px;
-
-  /* Backgrounds */
-  --ag-background-color: #ffffff;
-  --ag-header-background-color: #f9fafb;
-  --ag-odd-row-background-color: #ffffff;
-  --ag-row-hover-color: #f9fafb;
-  --ag-header-cell-hover-background-color: #f3f4f6;
-  --ag-selected-row-background-color: #fff7ed;
-  --ag-modal-overlay-background-color: rgba(0, 0, 0, 0.3);
-
-  /* Accent (Arda orange) */
-  --ag-range-selection-border-color: #FC5A29;
-  --ag-range-selection-background-color: rgba(252, 90, 41, 0.08);
-  --ag-checkbox-checked-color: #FC5A29;
-  --ag-input-focus-border-color: #FC5A29;
-  --ag-accent-color: #FC5A29;
-
-  /* Borders */
-  --ag-border-color: #e5e7eb;
-  --ag-row-border-color: #f3f4f6;
-  --ag-secondary-border-color: #e5e7eb;
-
-  /* Text */
-  --ag-header-foreground-color: #4b5563;
-  --ag-foreground-color: #1f2937;
-  --ag-secondary-foreground-color: #6b7280;
-  --ag-disabled-foreground-color: #9ca3af;
-
-  /* Sizing */
-  --ag-grid-size: 4px;
-  --ag-cell-horizontal-padding: 8px;
-  --ag-header-height: 36px;
-  --ag-row-height: 38px;
-
-  /* Shape */
-  --ag-wrapper-border-radius: 12px;
-  --ag-border-radius: 6px;
-  --ag-card-radius: 8px;
-
-  /* Shadows */
-  --ag-card-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1);
-  --ag-popup-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
-}
+/* Theme variables are set via JS theme API (see ItemsGrid.tsx ardaTheme).
+   This file contains only custom CSS overrides not expressible via theme params. */
 
 /* Header styling */
 .ag-theme-arda .ag-header-cell-label {


### PR DESCRIPTION
## Summary
- AG Grid v35 removed CSS-based theming — the `styles/` directory no longer exists
- The `ag-theme-arda` class with `--ag-*` CSS variables had no effect, leaving table rows invisible
- Migrated to the v35 JS Theme API: `themeQuartz.withParams({...})` passed via the `theme` prop

## Test plan
- [ ] Navigate to Step 8 (Review) of onboarding and verify the Item Ledger table renders all rows
- [ ] Verify the grid also renders in the side panel on earlier steps
- [ ] Confirm cell editing, row selection, and row drag still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)