### PR TITLE
Consolidate Gmail auth into Welcome step

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ export default function App() {
   
   // Track if user has completed onboarding
   const [hasCompletedOnboarding, setHasCompletedOnboarding] = useState(false);
+  const [initialReturnTo, setInitialReturnTo] = useState<string | null>(null);
   const [importedItemCount, setImportedItemCount] = useState(0);
   const [syncedTenant, setSyncedTenant] = useState<ArdaSyncedTenantContext | null>(null);
 
@@ -69,6 +70,9 @@ export default function App() {
           // Exchange token for session
           console.log('🔑 Exchanging auth token...');
           data = await authApi.exchangeToken(authToken);
+          // Preserve returnTo before cleaning URL (used after Gmail-linking redirect)
+          const returnTo = urlParams.get('returnTo');
+          if (returnTo) setInitialReturnTo(returnTo);
           // Clean up URL
           window.history.replaceState({}, '', window.location.pathname);
           if (!data.user) return;
@@ -257,6 +261,7 @@ export default function App() {
       onComplete={handleOnboardingComplete}
       onSkip={() => setHasCompletedOnboarding(true)}
       userProfile={{ name: userProfile.name, email: userProfile.email }}
+      initialReturnTo={initialReturnTo}
     />
   );
 }

--- a/src/views/OnboardingWelcomeStep.tsx
+++ b/src/views/OnboardingWelcomeStep.tsx
@@ -1,4 +1,5 @@
 import { Icons } from '../components/Icons';
+import { API_BASE_URL } from '../services/api';
 
 interface WelcomeStepItem {
   id: string;
@@ -12,6 +13,7 @@ interface OnboardingWelcomeStepProps {
   userProfile?: { name?: string; email?: string };
   onStartEmailSync: () => void;
   onSkipEmail: () => void;
+  isGmailConnected: boolean;
 }
 
 export const OnboardingWelcomeStep: React.FC<OnboardingWelcomeStepProps> = ({
@@ -19,8 +21,18 @@ export const OnboardingWelcomeStep: React.FC<OnboardingWelcomeStepProps> = ({
   userProfile,
   onStartEmailSync,
   onSkipEmail,
+  isGmailConnected,
 }) => {
   const firstName = userProfile?.name?.split(' ')[0];
+
+  const handleStartEmailSync = () => {
+    if (isGmailConnected) {
+      onStartEmailSync();
+    } else {
+      // Link Gmail via Google OAuth, then return to start email sync
+      window.location.href = `${API_BASE_URL}/auth/google?returnTo=email`;
+    }
+  };
 
   return (
     <div className="space-y-5">
@@ -65,11 +77,11 @@ export const OnboardingWelcomeStep: React.FC<OnboardingWelcomeStepProps> = ({
       <div className="flex flex-col sm:flex-row gap-3">
         <button
           type="button"
-          onClick={onStartEmailSync}
+          onClick={handleStartEmailSync}
           className="btn-arda-primary flex items-center justify-center gap-2 px-6 py-3"
         >
           <Icons.Mail className="w-4 h-4" />
-          Start email sync
+          {isGmailConnected ? 'Start email sync' : 'Connect Gmail & start sync'}
         </button>
         <button
           type="button"

--- a/src/views/SupplierSetup.tsx
+++ b/src/views/SupplierSetup.tsx
@@ -9,7 +9,6 @@ import {
   isSessionExpiredError,
   gmailApi,
   ApiRequestError,
-  API_BASE_URL,
 } from '../services/api';
 import { mergeSuppliers } from '../utils/supplierUtils';
 import {
@@ -990,24 +989,14 @@ export const SupplierSetup: React.FC<SupplierSetupProps> = ({
       {!isGmailConnected && (
         <div className="border border-arda-border rounded-2xl p-6 bg-arda-bg-secondary">
           <div className="flex items-start gap-4">
-            <div className="w-12 h-12 rounded-xl bg-orange-500 text-white flex items-center justify-center">
+            <div className="w-12 h-12 rounded-xl bg-gray-400 text-white flex items-center justify-center">
               <Icons.Mail className="w-6 h-6" />
             </div>
             <div className="flex-1">
-              <h3 className="text-lg font-semibold text-arda-text-primary">Connect Gmail to continue</h3>
+              <h3 className="text-lg font-semibold text-arda-text-primary">Gmail not connected</h3>
               <p className="text-sm text-arda-text-secondary mt-1">
-                {gmailStatusError || 'Link Gmail to scan your inbox for purchase orders and receipts.'}
+                {gmailStatusError || 'Go back to the Welcome step and click "Connect Gmail & start sync" to link your Google account, or skip this step.'}
               </p>
-              <button
-                type="button"
-                onClick={() => {
-                  window.location.href = `${API_BASE_URL}/auth/google?returnTo=email`;
-                }}
-                className="mt-4 inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-arda-accent text-white font-semibold hover:bg-arda-accent/90 transition-colors"
-              >
-                <Icons.Link className="w-4 h-4" />
-                Connect Gmail
-              </button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- **Fix local auth login** not transitioning to onboarding (missing `onLoginSuccess` prop)
- **Fix Gmail status endpoint** and cross-origin token exchange for deployed auth flow
- **Remove second Gmail OAuth prompt** from the Email step — Gmail linking now happens from the Welcome step's "Start email sync" button, with auto-return via `returnTo=email` param

## Test plan
- [ ] Google OAuth user: login → Welcome → "Start email sync" → advances to Email step (no second auth prompt)
- [ ] Local auth user: login → Welcome → "Connect Gmail & start sync" → Google OAuth → returns to Email step with sync started
- [ ] Skip flow: login → Welcome → "Skip" → proceeds without Gmail prompt
- [ ] All 76 existing tests pass (`npx vitest run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)