### PR TITLE
chore(vercel): use npm ci + pin npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ export default defineConfig([
 2. `npm run build` (server) – compiles the Node API via `tsc` (the `start` script runs the emitted `dist/index.js`).
 
 ### Hosting notes (Vercel / Railway)
+- In Vercel Project Settings → General, set **Node.js Version** to **20.x** (this repo enforces `>=20 <21`).
 - Set `FRONTEND_URL` to the deployed Vercel domain so OAuth redirects and CORS match.
 - Set `BACKEND_URL` for OAuth callbacks in `server/src/routes/auth.ts` and `server/src/routes/integrations.ts`.
 - Store the Redis URL and Postgres `DATABASE_URL` in the platform secrets; both are required before deploying.

--- a/REPO_DOCUMENTATION.md
+++ b/REPO_DOCUMENTATION.md
@@ -746,6 +746,7 @@ export default defineConfig([
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "packageManager": "npm@10.8.2",
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
@@ -37903,7 +37904,7 @@ export default {
     { "src": "package.json", "use": "@vercel/static-build", "config": { "distDir": "dist" } }
   ],
   "buildCommand": "npm run build",
-  "installCommand": "npm install",
+  "installCommand": "npm ci",
   "outputDirectory": "dist",
   "framework": "vite",
   "rewrites": [
@@ -37990,4 +37991,3 @@ export default defineConfig({
 8. **Binary assets**: `public/vite.svg` and `src/assets/react.svg` are standard Vite/React logos.
 9. **Railway deployment**: Uses project ID `f7c96f7b-ed85-4ae9-9428-de3888942936` and service name `order-pulse-api`.
 10. **Vercel rewrites**: API calls are proxied to `https://order-pulse-api-production.up.railway.app`.
-

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "packageManager": "npm@10.8.2",
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",

--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,7 @@
     { "src": "package.json", "use": "@vercel/static-build", "config": { "distDir": "dist" } }
   ],
   "buildCommand": "npm run build",
-  "installCommand": "npm install",
+  "installCommand": "npm ci",
   "outputDirectory": "dist",
   "framework": "vite",
   "rewrites": [


### PR DESCRIPTION
## Summary
- Use deterministic installs on Vercel by switching `installCommand` to `npm ci`.
- Pin npm via `packageManager: npm@10.8.2` to reduce CI drift.
- Document that Vercel should use Node 20.x (repo enforces `>=20 <21`).

## Testing
- `npm run build`

## Follow-up
- In Vercel Project Settings → General, set **Node.js Version** to **20.x** and redeploy to confirm the install step passes.