### PR TITLE
chore(ci): clean up dead code in Railway deploy step

### DIFF
--- a/.github/workflows/railway-deploy.yml
+++ b/.github/workflows/railway-deploy.yml
@@ -100,13 +100,6 @@ jobs:
         working-directory: server
         run: |
           set -euo pipefail
-          export PATH="$HOME/.railway/bin:$PATH"
-          if [ -z "${RAILWAY_TOKEN:-}" ]; then
-            echo "::error title=Missing RAILWAY_TOKEN secret::Add a valid Railway token to repo secrets as RAILWAY_TOKEN."
-            exit 1
-          fi
-
-          railway --version
 
           LOG_FILE="$(mktemp)"
           if ! railway up --ci --project "$RAILWAY_PROJECT_ID" --environment "$RAILWAY_ENVIRONMENT" --service "$RAILWAY_SERVICE" 2>&1 | tee "$LOG_FILE"; then


### PR DESCRIPTION
## Summary
- Remove stale `$HOME/.railway/bin` PATH export (CLI now installed via npm global)
- Remove duplicate `RAILWAY_TOKEN` check (already validated in earlier step)
- Remove duplicate `railway --version` (already verified after install)

## Context
Follow-up to #15 — the npm-based CLI install made these lines in the deploy step unreachable or redundant.

## Test plan
- [ ] Verify workflow YAML is valid (no syntax errors)
- [ ] Confirm deploy step still runs `railway up` with proper error handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)