### PR TITLE
Replace template favicon with Arda icon

### DIFF
--- a/public/vite.svg
+++ b/public/vite.svg
@@ -1,1 +1,13 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" class="iconify iconify--logos" width="31.88" height="32" preserveAspectRatio="xMidYMid meet" viewBox="0 0 256 257"><defs><linearGradient id="IconifyId1813088fe1fbc01fb466" x1="-.828%" x2="57.636%" y1="7.652%" y2="78.411%"><stop offset="0%" stop-color="#41D1FF"></stop><stop offset="100%" stop-color="#BD34FE"></stop></linearGradient><linearGradient id="IconifyId1813088fe1fbc01fb467" x1="43.376%" x2="50.316%" y1="2.242%" y2="89.03%"><stop offset="0%" stop-color="#FFEA83"></stop><stop offset="8.333%" stop-color="#FFDD35"></stop><stop offset="100%" stop-color="#FFA800"></stop></linearGradient></defs><path fill="url(#IconifyId1813088fe1fbc01fb466)" d="M255.153 37.938L134.897 252.976c-2.483 4.44-8.862 4.466-11.382.048L.875 37.958c-2.746-4.814 1.371-10.646 6.827-9.67l120.385 21.517a6.537 6.537 0 0 0 2.322-.004l117.867-21.483c5.438-.991 9.574 4.796 6.877 9.62Z"></path><path fill="url(#IconifyId1813088fe1fbc01fb467)" d="M185.432.063L96.44 17.501a3.268 3.268 0 0 0-2.634 3.014l-5.474 92.456a3.268 3.268 0 0 0 3.997 3.378l24.777-5.718c2.318-.535 4.413 1.507 3.936 3.838l-7.361 36.047c-.495 2.426 1.782 4.5 4.151 3.78l15.304-4.649c2.372-.72 4.652 1.36 4.15 3.788l-11.698 56.621c-.732 3.542 3.979 5.473 5.943 2.437l1.313-2.028l72.516-144.72c1.215-2.423-.88-5.186-3.54-4.672l-25.505 4.922c-2.396.462-4.435-1.77-3.759-4.114l16.646-57.705c.677-2.35-1.37-4.583-3.769-4.113Z"></path></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Arda">
+  <defs>
+    <linearGradient id="arda-favicon-gradient" x1="8" x2="56" y1="8" y2="56" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FC5A29" />
+      <stop offset="1" stop-color="#3B82F6" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="18" fill="url(#arda-favicon-gradient)" />
+  <path
+    d="M22 17h20l8 8v22H14V25l8-8Zm2.8 8h14.4l3.2 3.2v10.6c-2.7-2.4-6.2-3.8-10.4-3.8-7.3 0-12.9 4.2-16 12V28.2L24.8 25Zm7.2 15.2c3.7 0 6.5 1.4 8.3 4.2 1.8 2.8 2.4 6.6 1.5 11.6h-5.9c.6-3.1.4-5.5-.6-7.2-.9-1.7-2.4-2.5-4.4-2.5-2.1 0-3.8.8-5 2.5-1.1 1.8-1.6 4.2-1.3 7.2h-6.1c-.4-5 .6-8.9 2.9-11.7 2.3-2.8 5.8-4.1 10.6-4.1Z"
+    fill="#fff"
+  />
+</svg>


### PR DESCRIPTION
## Summary
- replace the stock Vite favicon asset with a branded Arda SVG favicon
- keep the existing /vite.svg path so current HTML and hosting config stay unchanged

## Verification
- rg -n "vite\.svg" index.html public vercel.json
- npm run build
- npm run lint