### PR TITLE
Add GTM-117 second-round interview execution plan for GTM Engineer

### DIFF
--- a/docs/hiring/2026-04-07-gtm-engineer-second-round-interview-plan.md
+++ b/docs/hiring/2026-04-07-gtm-engineer-second-round-interview-plan.md
@@ -1,0 +1,108 @@
+# GTM Engineer — Second-Round Interview Execution Plan
+
+**Issue:** GTM-117  
+**Prepared:** 2026-04-07 (UTC)  
+**Target completion date from issue notes:** 2026-04-01 (already elapsed)
+
+## Objective
+Close out second-round interviews for the GTM Engineer role with a consistent panel, calibrated scorecards, and a same-day debrief workflow.
+
+## Immediate status correction
+Because the stated target completion date (**2026-04-01**) is in the past, this plan assumes execution begins now and should be completed on an accelerated timeline.
+
+## Owners and RACI (proposed)
+- **Responsible:** Kyle (per imported issue metadata)
+- **Accountable:** Hiring manager for GTM Engineer
+- **Consulted:** Interview panel (Engineering, GTM, cross-functional partner)
+- **Informed:** Recruiting ops + leadership stakeholder for final hiring decision
+
+## 5-day accelerated schedule
+
+### Day 0 (today)
+1. Confirm final candidate shortlist for round 2.
+2. Lock panel lineup (3–4 interviewers maximum).
+3. Send scheduling windows (include two time-zone-friendly options).
+4. Confirm interview rubric and scoring anchors before invites go out.
+
+### Day 1–2
+1. Interview blocks held.
+2. Interviewers submit written feedback within 2 hours of each session.
+3. Recruiter/hiring lead nudges any missing scorecards by end of day.
+
+### Day 3
+1. Run 30-minute debrief.
+2. Capture explicit decision: **Advance / Hold / Reject**.
+3. If advancing, assign final-loop owner and same-day outreach.
+
+### Day 4–5
+1. Complete candidate communication.
+2. Update ATS/Linear notes with rationale and next action owner.
+3. Close GTM-117 once all second-round interviews and debrief artifacts are complete.
+
+## Interview panel structure (recommended)
+- **Interview A — GTM problem solving (45 min):** prioritization, tradeoff framing, experimentation mindset.
+- **Interview B — Technical fluency (45 min):** APIs, integrations, data handling, debugging approach.
+- **Interview C — Cross-functional execution (45 min):** stakeholder management, communication, ambiguity handling.
+- **Optional D — Hiring manager closeout (30 min):** role fit, motivation, risk check.
+
+## Scorecard rubric (1–4 scale)
+Use anchored scoring to avoid “strong yes/no” without evidence.
+
+1. **GTM systems thinking**
+   - 1: tactical only, weak prioritization
+   - 2: identifies some tradeoffs
+   - 3: strong structured thinking, good KPI alignment
+   - 4: exceptional prioritization under ambiguity, clear business impact framing
+
+2. **Technical execution for GTM workflows**
+   - 1: superficial technical understanding
+   - 2: basic fluency, limited depth
+   - 3: can independently scope and deliver integrations/automation
+   - 4: anticipates failure modes and designs scalable workflow architecture
+
+3. **Communication and stakeholder influence**
+   - 1: unclear or unstructured communication
+   - 2: generally clear but inconsistent influence
+   - 3: concise and persuasive with good listening
+   - 4: high-trust communicator, aligns cross-functional teams quickly
+
+4. **Ownership and pace**
+   - 1: low agency
+   - 2: executes with guidance
+   - 3: proactively drives outcomes
+   - 4: consistently identifies and closes high-impact gaps autonomously
+
+## Debrief template
+- Candidate:
+- Date/time:
+- Interviewers present:
+- Signals observed (evidence only):
+- Concerns / risks:
+- Final decision (Advance / Hold / Reject):
+- Conditions for advance (if applicable):
+- Owner for candidate communication:
+- Deadline for outreach:
+
+## Candidate scheduling message template
+Subject: Next steps — GTM Engineer interviews
+
+Hi {{CandidateName}},
+
+Thanks again for your time so far. We'd like to invite you to the second-round interview for the GTM Engineer role.
+
+Could you share your availability for the following windows?
+- {{Option1}}
+- {{Option2}}
+
+This round includes {{N}} conversations focused on GTM execution, technical fluency, and cross-functional collaboration.
+
+Looking forward to the next step,
+{{SenderName}}
+
+## Definition of done for GTM-117
+- [ ] Second-round panel finalized.
+- [ ] Candidate interviews scheduled and completed.
+- [ ] All scorecards submitted with evidence-based feedback.
+- [ ] Debrief completed and decision recorded.
+- [ ] Candidate communication sent.
+- [ ] Linear issue updated and moved out of Backlog/closed.


### PR DESCRIPTION
### Motivation
- Provide a concise, execution-ready plan to schedule and complete second-round interviews for Linear issue `GTM-117` and recover from the missed target date.
- Supply reusable templates (scorecard, debrief, scheduling message) and a clear definition-of-done so the responsible owner can act immediately.

### Description
- Add `docs/hiring/2026-04-07-gtm-engineer-second-round-interview-plan.md` with an accelerated 5-day timeline, proposed owners/RACI, recommended panel structure, an evidence-based scorecard rubric, a debrief template, a candidate scheduling email template, and a completion checklist.
- This is a documentation-only change with no modifications to runtime code or application behavior.

### Testing
- No automated tests were run because this is a documentation-only change; repository commit operations completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d5980dbdb88330a72400262dc74be5)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only addition with no runtime code or behavior changes.
> 
> **Overview**
> Adds a new hiring doc, `docs/hiring/2026-04-07-gtm-engineer-second-round-interview-plan.md`, defining an accelerated 5-day process to complete GTM-117 second-round interviews.
> 
> The doc includes proposed RACI/owners, a recommended interview panel structure, an evidence-anchored 1–4 scorecard rubric, debrief and candidate scheduling templates, and a definition-of-done checklist to drive same-day decisions and closeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f604d865450164253cadad298e3287502c4eb456. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->